### PR TITLE
introduce support for certificate files in rsa/hs confusion

### DIFF
--- a/jwt_tool.py
+++ b/jwt_tool.py
@@ -604,7 +604,7 @@ def checkAlgNone(headDict, tok2):
 def checkPubKey(headDict, tok2, pubKey):
     print("\n====================================================================\nThis option takes an available Public Key (the SSL certificate from \na webserver, for example?) and switches the RSA-signed \n(RS256/RS384/RS512) JWT that uses the Public Key as its 'secret'.\n====================================================================")
     try:
-        key = open(pubKey).read()
+        key = RSA.importKey(open(pubKey).read()).exportKey().decode() + "\n"
         print("File loaded: "+pubKey)
     except:
         print("[-] File not found")


### PR DESCRIPTION
After being frustrated for embarassingly long, I figured out that the JWT algorithm replacement attack only accepts actual public keys, not certs. I hope to spare someone else the headbanging.

Reworked the way public key files are ingested for the rsa/hs confusion
attack, so that passing a .509 certificate works as well.
This was done in order to equalise the behaviour with option "8: Verify
RSA sifnature against a Public Key", which accepts certificate .pem
files.
This changelist does *not* change the current behaviour of the tool - passing in a public key file still works as expected.