### PR TITLE
corrected a TypeError (the JSON object must be str, not "bytes")

### DIFF
--- a/jwt_tool.py
+++ b/jwt_tool.py
@@ -1151,8 +1151,8 @@ def validateToken():
         contents = contents.encode()
         head = base64.b64decode(tok1 + "=" * (-len(tok1) % 4))
         payl = base64.b64decode(tok2 + "=" * (-len(tok2) % 4))
-        headDict = json.loads(head, object_pairs_hook=OrderedDict)
-        paylDict = json.loads(payl, object_pairs_hook=OrderedDict)
+        headDict = json.loads(head.decode("utf-8"), object_pairs_hook=OrderedDict)
+        paylDict = json.loads(payl.decode("utf-8"), object_pairs_hook=OrderedDict)
     except:
         print("Oh noes! Invalid token")
         exit(1)


### PR DESCRIPTION
Due to the lines 1154 and 1155.

It ended up with:

``` text
Oh noes! Invalid token
```

I just converted bytes to str using `.decode("utf-8")`.

Do you agree it is safe to assume the data will be UTF-8 encoded?