### PR TITLE
Fixes input values to allow any JSON object

### DIFF
--- a/jwt_tool.py
+++ b/jwt_tool.py
@@ -617,6 +617,17 @@ def checkPubKey(headDict, tok2, pubKey):
     print("\nSet this new token as the AUTH cookie, or session/local storage data (as appropriate for the web application).\n(This will only be valid on unpatched implementations of JWT.)")
     print("\n"+newTok+"."+newSig)
 
+def getVal(promptString):
+    newVal = input(promptString)
+    try:
+        newVal = json.loads(newVal)
+    except ValueError:
+        try:
+            newVal = json.loads(newVal.replace("'", '"'))
+        except ValueError:
+            pass
+    return newVal
+
 def tamperToken(paylDict, headDict, sig):
     print("\n====================================================================\nThis option allows you to tamper with the header, contents and \nsignature of the JWT.\n====================================================================")
     print("\nToken header values:")
@@ -698,13 +709,13 @@ def tamperToken(paylDict, headDict, sig):
             else:
                 print("\nCurrent value of "+headList[selection]+" is: "+str(headDict[headList[selection]]))
                 print("Please enter new value and hit ENTER")
-                newVal = input("> ")
+                newVal = getVal("> ")
             headDict[headList[selection]] = newVal
         elif selection == i+1:
             print("Please enter new Key and hit ENTER")
             newPair = input("> ")
             print("Please enter new value for "+newPair+" and hit ENTER")
-            newVal = input("> ")
+            newVal = getVal("> ")
             headList.append(newPair)
             headDict[headList[selection]] = newVal
         elif selection == i+2:
@@ -749,17 +760,13 @@ def tamperToken(paylDict, headDict, sig):
         if selection<len(paylList) and selection>0:
             print("\nCurrent value of "+paylList[selection]+" is: "+str(paylDict[paylList[selection]]))
             print("Please enter new value and hit ENTER")
-            newVal = input("> ")
+            newVal = getVal("> ")
             paylDict[paylList[selection]] = newVal
         elif selection == i+1:
             print("Please enter new Key and hit ENTER")
             newPair = input("> ")
             print("Please enter new value for "+newPair+" and hit ENTER")
-            newVal = input("> ")
-            try:
-                newVal = int(newVal)
-            except:
-                pass
+            newVal = getVal("> ")
             paylList.append(newPair)
             paylDict[paylList[selection]] = newVal
         elif selection == i+2:

--- a/jwt_tool.py
+++ b/jwt_tool.py
@@ -17,9 +17,9 @@ import argparse
 import datetime
 from collections import OrderedDict
 try:
-    from Cryptodome.Signature import PKCS1_v1_5, DSS, pss
-    from Cryptodome.Hash import SHA256, SHA384, SHA512
-    from Cryptodome.PublicKey import RSA, ECC
+    from Crypto.Signature import PKCS1_v1_5, DSS, pss
+    from Crypto.Hash import SHA256, SHA384, SHA512
+    from Crypto.PublicKey import RSA, ECC
 except:
     print("WARNING: Cryptodome libraries not imported - these are needed for asymmetric crypto signing and verifying")
     print("On most Linux systems you can run the following command to install:")


### PR DESCRIPTION
Currently, when modifying a token attribute's value, it is not possible to provide a valid JSON object, only strings are allowed (and integers @ line 760). This proved very limiting when the attribute is a list of values, or a more complex object.

I suggest that we try parsing the input to see if it's a JSON object and if so, convert it into a Python object so that it can be rewritten properly.

On a side node, as you know JSON doesn't allow single quotes for strings (like `{ "attr": 'hello' }`), but when displaying a list/dict/set of strings in Python, the prefered way of printing the string values is with single quotes, which makes editing very frustrating as a user would just write single quotes, but it wouldn't be considered valid JSON and so the almost-json-object would be written as a string. That's why `getVal` tries to replace `'` with `"` and see if it becomes valid.