### PR TITLE
Improves castInput to allow any JSON object as attribute value

### DIFF
--- a/jwt_tool.py
+++ b/jwt_tool.py
@@ -82,24 +82,14 @@ def crackSig(sig, contents):
         print(utf8errors, " UTF-8 incompatible passwords skipped")
 
 def castInput(newInput):
-    if "\"" in newInput:
-        return newInput.strip("\"")
-    elif newInput == "True" or newInput == "true":
-        return True
-    elif newInput == "False" or newInput == "false":
-        return False
-    elif newInput == "null":
-        return None
-    else:
+    try:
+        newInput = json.loads(newInput)
+    except ValueError:
         try:
-            numInput = float(newInput)
-            try:
-                intInput = int(newInput)
-                return intInput
-            except:
-                return numInput
-        except:
-            return str(newInput)
+            newInput = json.loads(newInput.replace("'", "\""))
+        except ValueError:
+            pass
+    return newInput
 
 def testKey(key, sig, contents, headDict, quiet):
     if headDict["alg"] == "HS256":
@@ -636,6 +626,17 @@ def checkPubKey(headDict, tok2, pubKey):
     newSig = base64.urlsafe_b64encode(hmac.new(key.encode(),newTok.encode(),hashlib.sha256).digest()).decode('UTF-8').strip("=")
     print("\nSet this new token as the AUTH cookie, or session/local storage data (as appropriate for the web application).\n(This will only be valid on unpatched implementations of JWT.)")
     print("\n"+newTok+"."+newSig)
+
+def getVal(promptString):
+    newVal = input(promptString)
+    try:
+        newVal = json.loads(newVal)
+    except ValueError:
+        try:
+            newVal = json.loads(newVal.replace("'", '"'))
+        except ValueError:
+            pass
+    return newVal
 
 def tamperToken(paylDict, headDict, sig):
     print("\n====================================================================\nThis option allows you to tamper with the header, contents and \nsignature of the JWT.\n(Force string values in claims by enclosing in \"double quotes\"\n====================================================================")


### PR DESCRIPTION
Following PR #15 , this introduces a better way to parse attribute values provided by the user. Does so by leveraging `json.loads()` ability to identify and convert into Python equivalent any JSON object, including complex values like lists, objects etc. Doesn't break current single atomic values conversion, i.e. `type(json.loads("1")) == int`, `type(json.loads("true")) == bool`, etc.

Before the suggested changes:

```
Current value of my_attr is: {'attr1': 'foo', 'attr2': 'bar'}
Please enter new value and hit ENTER
> {"attr1": "food", "attr2": "baz"}
[1] my_attr = "{'attr1': 'food', 'attr2': 'baz'}"   # This is a string and not an object !
```
And after
```
Current value of my_attr is: {'attr1': 'foo', 'attr2': 'bar'}
Please enter new value and hit ENTER
> {"attr1": "food", "attr2": "baz"}
[1] my_attr = {'attr1': 'food', 'attr2': 'baz'}  # This is a a JSON object, i.e. a Python dict
```