### PR TITLE
fix: -rh ""

### DIFF
--- a/jwt_tool.py
+++ b/jwt_tool.py
@@ -141,8 +141,9 @@ def sendToken(token, cookiedict, track, headertoken="", postdata=None):
     headers = {'User-agent': config['customising']['useragent']+" "+track}
     if headertoken:
         for eachHeader in headertoken:
-            headerName, headerVal = eachHeader.split(":",1)
-            headers[headerName] = headerVal.lstrip(" ")
+            if eachHeader.replace(' ','') != "":
+                headerName, headerVal = eachHeader.split(":",1)
+                headers[headerName] = headerVal.lstrip(" ")
     try:
         if config['services']['proxy'] == "False":
             if postdata:


### PR DESCRIPTION
Python Error:
```
[+] Sending token
Traceback (most recent call last):
  File "/jwt_tool/jwt_tool.py", line 2034, in <module>
    rejigToken(headDict, paylDict, sig)
  File "/jwt_tool/jwt_tool.py", line 1330, in rejigToken
    jwtOut(newContents+"."+sig, "Sending token")
  File "/jwt_tool/jwt_tool.py", line 232, in jwtOut
    resData = sendToken(token, cookiedict, logID, headertoken[0], posttoken[0])
  File "/jwt_tool/jwt_tool.py", line 144, in sendToken
    headerName, headerVal = eachHeader.split(":",1)
ValueError: not enough values to unpack (expected 2, got 1)

```

When -rh is equal to "" the script tries to do a split and ends up giving an error.

I added a condition to check this.