### PR TITLE
change the case of alg to match -S expected input

### DIFF
--- a/jwt_tool.py
+++ b/jwt_tool.py
@@ -671,7 +671,7 @@ def testKey(key, sig, contents, headDict, quiet):
             cprintc("[+] CORRECT key found:\n"+key.decode('UTF-8'), "green")
         else:
             cprintc("[+] "+key.decode('UTF-8')+" is the CORRECT key!", "green")
-        cprintc("You can tamper/fuzz the token contents (-T/-I) and sign it using:\npython3 jwt_tool.py [options here] -S "+str(headDict["alg"])+" -p \""+key.decode('UTF-8')+"\"", "cyan")
+        cprintc("You can tamper/fuzz the token contents (-T/-I) and sign it using:\npython3 jwt_tool.py [options here] -S "+str(headDict["alg"]).lower()+" -p \""+key.decode('UTF-8')+"\"", "cyan")
         return cracked
     else:
         cracked = False


### PR DESCRIPTION
The -S parameter requires the algorithm to be passed in lowercase. After cracking a secret, if the algorithm in the JWT is in uppercase, it will prompt you to run -S with an uppercase alg, which will not work.