### PR TITLE
Add XDG_CONFIG_HOME support

### DIFF
--- a/jwt_tool.py
+++ b/jwt_tool.py
@@ -1884,7 +1884,11 @@ if __name__ == '__main__':
     if not args.bare:
         printLogo()
     try:
-        path = os.path.expanduser("~/.jwt_tool")
+        xdg_config_home = os.environ.get("XDG_CONFIG_HOME", False)
+        if xdg_config_home:
+            path = os.path.expanduser(os.path.normpath(xdg_config_home + "/jwt_tool"))
+        else:
+            path = os.path.expanduser("~/.jwt_tool")
         if not os.path.exists(path):
             os.makedirs(path)
     except:


### PR DESCRIPTION
This PR adds support for the [XDG Base Directory](https://wiki.archlinux.org/title/XDG_Base_Directory) specification.

When a user has the `$XDG_CONFIG_HOME` environment variable set, the config folder will be created at `$XDG_CONFIG_HOME/jwt_tool`. If this environment variable is not set, then the default `~/.jwt_tool` path is used.

This fixes the request in https://github.com/ticarpi/jwt_tool/issues/53

Thank you for creating such an awesome tool!