### PR TITLE
sqlmap style request option

### DIFF
--- a/jwt_tool.py
+++ b/jwt_tool.py
@@ -1919,22 +1919,38 @@ if __name__ == '__main__':
             url = first_line_remainder.split(' ', 1)[0]
             base_url = ''
         
+            in_headers = True
+            args.postdata = ''
+
             for line in file:
+                
                 line = line.strip()
                 if not line:
                     # Stop when reaching an empty line (end of headers)
-                    break
+                    in_headers = False
+                    continue
 
-                if line.lower().startswith('host:'):
-                    # Extract the host from the 'Host' header
-                    _, host = line.split(':', 1)
-                    host = host.strip()
-                    
-                    if ':' in host:
-                        host, port = host.split(':', 1)
+                if in_headers:
+                    if line.lower().startswith('host:'):
+                        # Extract the host from the 'Host' header
+                        _, host = line.split(':', 1)
+                        host = host.strip()
+                        
+                        if ':' in host:
+                            host, port = host.split(':', 1)
 
-                    base_url = f"https://{host}"
-                    break
+                        base_url = f"https://{host}"
+                    elif line.lower().startswith('cookie:'):
+                        cookie = line.lower().split(': ')[0]
+                        if not args.cookies:
+                            args.cookies = []
+                        args.cookies.append(cookie)
+                    else:
+                        if not args.headers:
+                            args.headers = []
+                        args.headers.append(line)
+                else:
+                    args.postdata += line
 
             if not port:
                 url_object = urlparse(url)
@@ -1942,8 +1958,7 @@ if __name__ == '__main__':
                     port = str(url_object.port)
 
         absolute_url = urljoin(base_url + (':' + port if port else ''), url)
-        print(absolute_url)
-        exit()
+        args.targeturl = absolute_url
 
     if args.targeturl:
         if args.cookies or args.headers or args.postdata:

--- a/jwt_tool.py
+++ b/jwt_tool.py
@@ -1828,6 +1828,8 @@ if __name__ == '__main__':
                         help="return TOKENS ONLY")
     parser.add_argument("-t", "--targeturl", action="store",
                         help="URL to send HTTP request to with new JWT")
+    parser.add_argument("-r", "--request", action="store",
+                        help="URL request to base on.")
     parser.add_argument("-rc", "--cookies", action="store",
                         help="request cookies to send with the forged HTTP request")
     parser.add_argument("-rh", "--headers", action="append",
@@ -2035,6 +2037,8 @@ if __name__ == '__main__':
         config['services']['proxy'] = "False"
     if args.noredir:
         config['services']['redir'] = "False"
+    if args.request:
+        config['argvals']['request'] = args.request
 
     if not args.crack and not args.exploit and not args.verify and not args.tamper and not args.injectclaims:
         rejigToken(headDict, paylDict, sig)

--- a/jwt_tool.py
+++ b/jwt_tool.py
@@ -1946,10 +1946,10 @@ if __name__ == '__main__':
                         base_url = f"{protocol}://{host}"
                         
                     elif line.lower().startswith('cookie:'):
-                        cookie = line.lower().split(': ')[0]
+                        cookie = line.split(': ')[1]
                         if not args.cookies:
-                            args.cookies = []
-                        args.cookies.append(cookie)
+                            args.cookies = ''
+                        args.cookies += cookie
                     else:
                         # Don't add user agent field, otherwise 'jwt_tool' in user agent will not work
                         if not line.lower().startswith('user-agent:'):
@@ -2017,7 +2017,7 @@ if __name__ == '__main__':
                 str(args.headers),
                 str(args.postdata)
             ])
-
+            
             try:
                 findJWT = re.search('eyJ[A-Za-z0-9_\/+-]*\.eyJ[A-Za-z0-9_\/+-]*\.[A-Za-z0-9._\/+-]*', searchString)[0]
             except:

--- a/jwt_tool.py
+++ b/jwt_tool.py
@@ -1951,9 +1951,11 @@ if __name__ == '__main__':
                             args.cookies = []
                         args.cookies.append(cookie)
                     else:
-                        if not args.headers:
-                            args.headers = []
-                        args.headers.append(line)
+                        # Don't add user agent field, otherwise 'jwt_tool' in user agent will not work
+                        if not line.lower().startswith('user-agent:'):
+                            if not args.headers:
+                                args.headers = []
+                            args.headers.append(line)
                 else:
                     args.postdata += line
 

--- a/jwt_tool.py
+++ b/jwt_tool.py
@@ -1830,7 +1830,9 @@ if __name__ == '__main__':
     parser.add_argument("-t", "--targeturl", action="store",
                         help="URL to send HTTP request to with new JWT")
     parser.add_argument("-r", "--request", action="store",
-                        help="URL request to base on.")
+                        help="URL request to base on")
+    parser.add_argument("-i", "--insecure", action="store_true",
+                        help="Use HTTP for passed request")
     parser.add_argument("-rc", "--cookies", action="store",
                         help="request cookies to send with the forged HTTP request")
     parser.add_argument("-rh", "--headers", action="append",
@@ -1939,7 +1941,10 @@ if __name__ == '__main__':
                         if ':' in host:
                             host, port = host.split(':', 1)
 
-                        base_url = f"https://{host}"
+                        protocol = "http" if args.insecure else "https"
+
+                        base_url = f"{protocol}://{host}"
+                        
                     elif line.lower().startswith('cookie:'):
                         cookie = line.lower().split(': ')[0]
                         if not args.cookies:

--- a/jwt_tool.py
+++ b/jwt_tool.py
@@ -17,6 +17,7 @@ import hmac
 import base64
 import json
 import random
+from urllib.parse import urljoin, urlparse
 import argparse
 from datetime import datetime
 import configparser
@@ -1908,6 +1909,42 @@ if __name__ == '__main__':
     with open(path+"/null.txt", 'w') as nullfile:
         pass
     findJWT = ""
+
+    if args.request:
+        port = ''
+
+        with open(args.request, 'r') as file:
+            first_line = file.readline().strip()
+            method, first_line_remainder = first_line.split(' ', 1)
+            url = first_line_remainder.split(' ', 1)[0]
+            base_url = ''
+        
+            for line in file:
+                line = line.strip()
+                if not line:
+                    # Stop when reaching an empty line (end of headers)
+                    break
+
+                if line.lower().startswith('host:'):
+                    # Extract the host from the 'Host' header
+                    _, host = line.split(':', 1)
+                    host = host.strip()
+                    
+                    if ':' in host:
+                        host, port = host.split(':', 1)
+
+                    base_url = f"https://{host}"
+                    break
+
+            if not port:
+                url_object = urlparse(url)
+                if url_object.port:
+                    port = str(url_object.port)
+
+        absolute_url = urljoin(base_url + (':' + port if port else ''), url)
+        print(absolute_url)
+        exit()
+
     if args.targeturl:
         if args.cookies or args.headers or args.postdata:
             jwt_count = 0


### PR DESCRIPTION
Added `-r` so request files can be passed, sqlmap style:

`./jwt_tool.py -r test-request.txt`

Where `test-request.txt` is an HTTP request, for example, copied from Burp. e.g.:

```
GET /api/v33/user HTTP/2
Host: attacker-site.co.uk
User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:103.0) Gecko/20100101 Firefox/103.0
Accept: application/json, text/plain, */*
Accept-Language: en
Accept-Encoding: gzip, deflate, br
Referer: https://attacker-site.co.uk/
X-Language-Code: en
X-Country-Code: de
X-Requested-With: XMLHttpRequest
Authorization: Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsb2dpbiI6InRpY2FycGkifQ.bsSwqj2c2uI9n7-ajmi3ixVGhPUiY7jO9SUn9dm15Po
Origin: https://attacker-site.co.uk
Sec-Fetch-Dest: empty
Sec-Fetch-Mode: cors
Sec-Fetch-Site: cross-site
Te: trailers

```

`-i` option added in case this has to be sent over plain HTTP instead of HTTPS.