### PR TITLE
Fix intendation/scope for block responsible of jku-var exchange.

### DIFF
--- a/jwt_tool.py
+++ b/jwt_tool.py
@@ -1433,10 +1433,10 @@ def scanModePlaybook():
         origjku = headDict["jku"]
     except:
         origjku = False
-        if config['services']['jwksloc']:
-            jku = config['services']['jwksloc']
-        else:
-            jku = config['services']['jwksdynamic']
+    if config['services']['jwksloc']:
+        jku = config['services']['jwksloc']
+    else:
+        jku = config['services']['jwksdynamic']
     newContents, newSig = exportJWKS(jku)
     jwtOut(newContents+"."+newSig, "Exploit: Spoof JWKS (-X s)", "Signed with JWKS at "+jku)
     if origjku:


### PR DESCRIPTION
I belive this addresses the problem described in issue #90. To reproduce the undefined var in line it I had to run in the scan mode "-M at" and you need a JWT that defines "jku" field. In that case the try block before succeds. That lead to the "jku" variable never to be defined.