### PR TITLE
Fix castInput function to handle OrderedDict conversion to JSON string

### DIFF
--- a/jwt_tool.py
+++ b/jwt_tool.py
@@ -590,6 +590,9 @@ def crackSig(sig, contents):
         cprintc(utf8errors, " UTF-8 incompatible passwords skipped", "cyan")
 
 def castInput(newInput):
+    if isinstance(newInput, OrderedDict):
+        newInput = json.dumps(newInput)
+    
     if "{" in str(newInput):
         try:
             jsonInput = json.loads(newInput)


### PR DESCRIPTION
This pull request fixes the `castInput` function to handle `OrderedDict` conversion to JSON string. This prevents errors when the input is an `OrderedDict`, ensuring it is properly converted and parsed.

### Changes Made
- Added a check for `OrderedDict` in the `castInput` function.
- Converted `OrderedDict` to JSON string before parsing.

### Before
![Screenshot 2024-06-12 025340](https://github.com/ticarpi/jwt_tool/assets/70060844/48e0a4f2-742f-4169-9e5b-062aff31c347)

### After
![Screenshot 2024-06-12 025744](https://github.com/ticarpi/jwt_tool/assets/70060844/72147073-dd46-4001-8ea3-b14aea2d89b3)
