### PR TITLE
Fix: Handle RFC3339 date format

### DIFF
--- a/jwt_tool.py
+++ b/jwt_tool.py
@@ -1190,7 +1190,10 @@ def dissectPayl(paylDict, count=False):
         else:
             placeholder = "+"
         if claim in ["exp", "nbf", "iat"]:
-            timestamp = datetime.fromtimestamp(int(paylDict[claim]))
+            try:
+                timestamp = datetime.fromtimestamp(int(paylDict[claim]))
+            except ValueError:
+                timestamp = datetime.fromisoformat(paylDict[claim])
             if claim == "exp":
                 if int(timestamp.timestamp()) < nowtime:
                     expiredtoken = True


### PR DESCRIPTION
This PR fixes #82.
The JWT Standard defines the Numerical Date as either a Unix Epoch in seconds or a non-integer value from RFC3339 (https://www.rfc-editor.org/rfc/rfc7519#section-2). Currently, passing a RFC3339 formatted date leads to a ValueError.
This Error gets caught and instead the date is parsed as ISO / RFC3339. If the date can also not be parsed as ISO, the script will still throw a value error.
Implementing further date parsing, for example for the date formats shown in #92 could be considered, but would not follow the standard.
Cheers, [JM-Lemmi](https://www.github.com/JM-Lemmi)