### PR TITLE
Add pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,18 @@
+[build-system]
+requires = [ "setuptools" ]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "JWT_Tool"
+version = "2.2.7"
+description = "The JSON Web Token Toolkit"
+authors = [ { name = "ticarpi" } ]
+license = { text = "GPL-3.0" }
+dynamic = [ "dependencies" ]
+
+[tool.setuptools]
+script-files = [ "jwt_tool.py" ]
+
+[tool.setuptools.dynamic]
+dependencies = { file = [ "requirements.txt"] }
+


### PR DESCRIPTION
The goal was to provide an minimal pyproject.toml to allow easier installation with pipx. E.g.
`pipx install git+https://github.com/ticarpi/jwt_tool.git`.

Example
```
thort@kali-vm~ $ sudo pipx install --global git+https://github.com/tobiashort/jwt_tool.git
  installed package JWT_Tool 2.2.7, installed using Python 3.12.7
  These apps are now globally available
    - jwt_tool
    - jwt_tool.py
done! ✨ 🌟 ✨
thort@kali-vm~ $ jwt_tool.py

        \   \        \         \          \                    \
   \__   |   |  \     |\__    __| \__    __|                    |
         |   |   \    |      |          |       \         \     |
         |        \   |      |          |    __  \     __  \    |
  \      |      _     |      |          |   |     |   |     |   |
   |     |     / \    |      |          |   |     |   |     |   |
\        |    /   \   |      |          |\        |\        |   |
 \______/ \__/     \__|   \__|      \__| \______/  \______/ \__|
 Version 2.2.7                \______|             @ticarpi

usage: jwt_tool.py [-h] [-b] [-t TARGETURL] [-r REQUEST] [-i] [-rc COOKIES] [-rh HEADERS]
                   [-pd POSTDATA] [-cv CANARYVALUE] [-np] [-nr] [-M MODE] [-X EXPLOIT] [-ju JWKSURL]
                   [-S SIGN] [-pr PRIVKEY] [-T] [-I] [-hc HEADERCLAIM] [-pc PAYLOADCLAIM]
                   [-hv HEADERVALUE] [-pv PAYLOADVALUE] [-C] [-d DICT] [-p PASSWORD] [-kf KEYFILE]
                   [-V] [-pk PUBKEY] [-jw JWKSFILE] [-Q QUERY] [-v]
                   [jwt]
No JWT provided
thort@kali-vm~ $
```