### PR TITLE
Fix: Canonicalization

### DIFF
--- a/jwt_tool.py
+++ b/jwt_tool.py
@@ -96,7 +96,7 @@ def createConfig():
         jwksbuild = buildJWKS(n, e, "jwt_tool")
         jwksout = {"keys": []}
         jwksout["keys"].append(jwksbuild)
-        fulljwks = json_escape(json.dumps(jwksout,separators=(",",":")), indent=4)
+        fulljwks = json_canon_escapeslash(json.dumps(jwksout,separators=(",",":")), indent=4)
         with open(jwksName, 'w') as test_jwks_out:
                 test_jwks_out.write(fulljwks)
         jwks_b64 = base64.urlsafe_b64encode(fulljwks.encode('ascii'))
@@ -271,8 +271,8 @@ def jwtOut(token, fromMod, desc=""):
     except:
         pass
 
-def json_escape(s):
-    if not args.encodeslashes:
+def json_canon_escapeslash(s):
+    if not args.canonicalizeslashes:
         return s
     else:
         s = s.replace("\\", "\\\\")
@@ -282,8 +282,8 @@ def json_escape(s):
 
 def json_canonicalize(s):
     headDict, paylDict, sig, contents = validateToken(jwt)
-    paylB64 = base64.urlsafe_b64encode(json_escape(json.dumps(paylDict,separators=(",",":"))).encode()).decode('UTF-8').strip("=")
-    headB64 = base64.urlsafe_b64encode(json_escape(json.dumps(headDict,separators=(",",":"))).encode()).decode('UTF-8').strip("=")
+    paylB64 = base64.urlsafe_b64encode(json_canon_escapeslash(json.dumps(paylDict,separators=(",",":"))).encode()).decode('UTF-8').strip("=")
+    headB64 = base64.urlsafe_b64encode(json_canon_escapeslash(json.dumps(headDict,separators=(",",":"))).encode()).decode('UTF-8').strip("=")
     return headB64 + "." + paylB64 + "." + sig
 
 def check_canonicalization(s) -> bool:
@@ -298,7 +298,7 @@ def setLog(jwt, genTime, logID, modulename, targetURL, additional):
 def buildHead(alg, headDict):
     newHead = headDict
     newHead["alg"] = alg
-    newHead = base64.urlsafe_b64encode(json_escape(json.dumps(newHead,separators=(",",":"))).encode()).decode('UTF-8').strip("=")
+    newHead = base64.urlsafe_b64encode(json_canon_escapeslash(json.dumps(newHead,separators=(",",":"))).encode()).decode('UTF-8').strip("=")
     return newHead
 
 def checkNullSig(contents):
@@ -329,7 +329,7 @@ def checkPubKeyExploit(headDict, paylB64, pubKey):
         exit(1)
     newHead = headDict
     newHead["alg"] = "HS256"
-    newHead = base64.urlsafe_b64encode(json_escape(json.dumps(headDict,separators=(",",":"))).encode()).decode('UTF-8').strip("=")
+    newHead = base64.urlsafe_b64encode(json_canon_escapeslash(json.dumps(headDict,separators=(",",":"))).encode()).decode('UTF-8').strip("=")
     newTok = newHead+"."+paylB64
     newSig = base64.urlsafe_b64encode(hmac.new(key.encode(),newTok.encode(),hashlib.sha256).digest()).decode('UTF-8').strip("=")
     return newTok, newSig
@@ -337,13 +337,13 @@ def checkPubKeyExploit(headDict, paylB64, pubKey):
 def injectpayloadclaim(payloadclaim, injectionvalue):
     newpaylDict = paylDict
     newpaylDict[payloadclaim] = castInput(injectionvalue)
-    newPaylB64 = base64.urlsafe_b64encode(json_escape(json.dumps(newpaylDict,separators=(",",":"))).encode()).decode('UTF-8').strip("=")
+    newPaylB64 = base64.urlsafe_b64encode(json_canon_escapeslash(json.dumps(newpaylDict,separators=(",",":"))).encode()).decode('UTF-8').strip("=")
     return newpaylDict, newPaylB64
 
 def injectheaderclaim(headerclaim, injectionvalue, esc):
     newheadDict = headDict
     newheadDict[headerclaim] = castInput(injectionvalue)
-    newHeadB64 = base64.urlsafe_b64encode(json_escape(json.dumps(newheadDict,separators=(",",":"))).encode()).decode('UTF-8').strip("=")
+    newHeadB64 = base64.urlsafe_b64encode(json_canon_escapeslash(json.dumps(newheadDict,separators=(",",":"))).encode()).decode('UTF-8').strip("=")
     return newheadDict, newHeadB64
 
 def tamperToken(paylDict, headDict, sig):
@@ -775,10 +775,10 @@ def jwksGen(headDict, paylDict, jku, privKey, kid="jwt_tool"):
         cprintc("Invalid Private Key", "red")
         exit(1)
     newSig = base64.urlsafe_b64encode(signature).decode('UTF-8').strip("=")
-    jwksout = json_escape(json.dumps(newjwks,separators=(",",":"), indent=4))
+    jwksout = json_canon_escapeslash(json.dumps(newjwks,separators=(",",":"), indent=4))
     jwksbuild = {"keys": []}
     jwksbuild["keys"].append(newjwks)
-    fulljwks = json_escape(json.dumps(jwksbuild,separators=(",",":"), indent=4))
+    fulljwks = json_canon_escapeslash(json.dumps(jwksbuild,separators=(",",":"), indent=4))
     if config['crypto']['jwks'] == "":
         jwksName = "jwks_jwttool_RSA_"+nowtime+".json"
         with open(jwksName, 'w') as test_jwks_out:
@@ -1190,9 +1190,9 @@ def getVal(promptString):
 
 def genContents(headDict, paylDict, newContents=""):
     if paylDict == {}:
-        newContents = base64.urlsafe_b64encode(json_escape(json.dumps(headDict,separators=(",",":")).encode())).decode('UTF-8').strip("=")+"."
+        newContents = base64.urlsafe_b64encode(json_canon_escapeslash(json.dumps(headDict,separators=(",",":")).encode())).decode('UTF-8').strip("=")+"."
     else:
-        newContents = base64.urlsafe_b64encode(json_escape(json.dumps(headDict,separators=(",",":"))).encode()).decode('UTF-8').strip("=")+"."+base64.urlsafe_b64encode(json_escape(json.dumps(paylDict,separators=(",",":"))).encode()).decode('UTF-8').strip("=")
+        newContents = base64.urlsafe_b64encode(json_canon_escapeslash(json.dumps(headDict,separators=(",",":"))).encode()).decode('UTF-8').strip("=")+"."+base64.urlsafe_b64encode(json_canon_escapeslash(json.dumps(paylDict,separators=(",",":"))).encode()).decode('UTF-8').strip("=")
     return newContents.encode().decode('UTF-8')
 
 def dissectPayl(paylDict, count=False):
@@ -1681,7 +1681,7 @@ def reflectedClaims():
     for claim in paylDict:
         tmpValue = paylDict[claim]
         paylDict[claim] = checkVal+claim
-        tmpContents = base64.urlsafe_b64encode(json_escape(json.dumps(headDict,separators=(",",":"))).encode()).decode('UTF-8').strip("=")+"."+base64.urlsafe_b64encode(json_escape(json.dumps(paylDict,separators=(",",":"))).encode()).decode('UTF-8').strip("=")
+        tmpContents = base64.urlsafe_b64encode(json_canon_escapeslash(json.dumps(headDict,separators=(",",":"))).encode()).decode('UTF-8').strip("=")+"."+base64.urlsafe_b64encode(json_canon_escapeslash(json.dumps(paylDict,separators=(",",":"))).encode()).decode('UTF-8').strip("=")
         jwtOut(tmpContents+"."+sig, "Claim processing check in "+claim+" claim", "Token sent to check if the signature is checked before the "+claim+" claim is processed")
         if checkVal+claim in config['argvals']['rescontent']:
             cprintc("Injected value in "+claim+" claim was observed - "+checkVal+claim, "red")
@@ -1865,8 +1865,8 @@ if __name__ == '__main__':
                         help="disable redirects for current request (change in jwtconf.ini if permanent)")
     parser.add_argument("-M", "--mode", action="store",
                         help="Scanning mode:\npb = playbook audit\ner = fuzz existing claims to force errors\ncc = fuzz common claims\nat - All Tests!")
-    parser.add_argument("-es", "--encodeslashes", action="store_true",
-                        help="Encode forward and backslashes in json.")
+    parser.add_argument("-cs", "--canonicalizeslashes", action="store_true",
+                        help="Fix canonicalization errors with encoded slashes. Turns '/' into '\\/' and '\\' into '\\\\'.")
     parser.add_argument("-X", "--exploit", action="store",
                         help="eXploit known vulnerabilities:\na = alg:none\nn = null signature\nb = blank password accepted in signature\ns = spoof JWKS (specify JWKS URL with -ju, or set in jwtconf.ini to automate this attack)\nk = key confusion (specify public key with -pk)\ni = inject inline JWKS")
     parser.add_argument("-ju", "--jwksurl", action="store",
@@ -2057,7 +2057,7 @@ if __name__ == '__main__':
         cprintc("No JWT provided", "red")
         exit(1)
     if not check_canonicalization(findJWT):
-        cprintc("Issue in canonicalization of JWT. Try --encodeslashes or report to https://github.com/ticarpi/jwt_tool/issues/48.", "red")
+        cprintc("Issue in canonicalization of JWT. Try --canonicalizeslashes or report to https://github.com/ticarpi/jwt_tool/issues/48.", "red")
         cprintc("Canonicalized JWT: "+json_canonicalize(findJWT)+"\n", "red")
         exit(1)
     if args.mode:
@@ -2082,7 +2082,7 @@ if __name__ == '__main__':
         else:
             config['argvals']['sigType'] = args.sign
     headDict, paylDict, sig, contents = validateToken(jwt)
-    paylB64 = base64.urlsafe_b64encode(json_escape(json.dumps(paylDict,separators=(",",":"))).encode()).decode('UTF-8').strip("=")
+    paylB64 = base64.urlsafe_b64encode(json_canon_escapeslash(json.dumps(paylDict,separators=(",",":"))).encode()).decode('UTF-8').strip("=")
     config['argvals']['overridesub'] = "false"
     if args.targeturl:
         config['argvals']['targetUrl'] = args.targeturl.replace('%','%%')


### PR DESCRIPTION
This PR addresses #48, but does not completely fix it. As discussed in the issue, defining some edgecases is not as clear.
This PR addresses issues with encoding of / and \\. The new flag -cs or --canonicalizeslashes will escape the slashes.
The tool will also check on startup, if a JWT gets modified by simple json.loads and json.dumps and will warn the user about canonicalization issues. Some of them might be fixable and could be fixed with future flags, some might be harder to fix.
Cheers, [JM-Lemmi](https://www.github.com/JM-Lemmi)