### PR TITLE
Fix TypeError when parsing nested JSON objects in JWT payload

### DIFF
--- a/jwt_tool.py
+++ b/jwt_tool.py
@@ -1219,7 +1219,19 @@ def dissectPayl(paylDict, count=False):
         elif isinstance(paylDict[claim], dict):
                 cprintc("["+placeholder+"] "+claim+" = JSON object:", "green")
                 for subclaim in paylDict[claim]:
-                    if type(castInput(paylDict[claim][subclaim])) == str:
+                    # Handle nested dicts (e.g., resource_access['account'] = {'roles': [...]})
+                    if isinstance(paylDict[claim][subclaim], dict):
+                        cprintc("    [+] "+subclaim+" = JSON object:", "green")
+                        for nested_subclaim in paylDict[claim][subclaim]:
+                            if isinstance(paylDict[claim][subclaim][nested_subclaim], list):
+                                cprintc("        [+] "+nested_subclaim+" = "+str(paylDict[claim][subclaim][nested_subclaim]), "green")
+                            elif type(paylDict[claim][subclaim][nested_subclaim]) == str:
+                                cprintc("        [+] "+nested_subclaim+" = \""+str(paylDict[claim][subclaim][nested_subclaim])+"\"", "green")
+                            else:
+                                cprintc("        [+] "+nested_subclaim+" = "+str(paylDict[claim][subclaim][nested_subclaim]), "green")
+                    elif isinstance(paylDict[claim][subclaim], list):
+                        cprintc("    [+] "+subclaim+" = "+str(paylDict[claim][subclaim]), "green")
+                    elif type(castInput(paylDict[claim][subclaim])) == str:
                         cprintc("    [+] "+subclaim+" = \""+str(paylDict[claim][subclaim])+"\"", "green")
                     elif paylDict[claim][subclaim] == None:
                         cprintc("    [+] "+subclaim+" = null", "green")


### PR DESCRIPTION
Fixes issue where dissectPayl() function failed when encountering nested dict structures (e.g., resource_access['account'] = {'roles': [...]}).

The original code attempted to call castInput() on dict objects, which caused json.loads() to fail with TypeError: the JSON object must be str, bytes or bytearray, not OrderedDict.

Solution: Added type checking to handle nested dicts and lists before attempting to parse them as strings. Now properly displays nested JSON structures with proper indentation.

Fixes parsing of tokens with complex nested structures like Keycloak tokens containing resource_access and realm_access objects.