### PR TITLE
Fix multi JWTs in headers check not running

### DIFF
--- a/jwt_tool.py
+++ b/jwt_tool.py
@@ -222,7 +222,7 @@ def jwtOut(token, fromMod, desc=""):
                     headerSub = p.subn(token, eachHeader, 0)
                     headertoken[0].append(headerSub[0])
                     if headerSub[1] == 1:
-                        headertoken[1] = 1
+                        headertoken[1] += 1
                 except:
                     pass
         else:


### PR DESCRIPTION
The condition `if cookietoken[1] == 1 or headertoken[1] == 1 or posttoken[1]:` checks that only one JWT is present in either the request cookies or headers. Any requests containing more than one token in the cookies or headers are rejected.

Currently, even if multiple JWTs were submitted in the headers, such as:
```
$ python3 ./jwt_tool.py -rh 'JWT1: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWUsImlhdCI6MTUxNjIzOTAyMn0.KMUFsIDTnFmyG3nMiGM6H9FNFUROf3wh7SmqJp-QV30' -rh 'JWT2: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWUsImlhdCI6MTUxNjIzOTAyMn0.KMUFsIDTnFmyG3nMiGM6H9FNFUROf3wh7SmqJp-QV30' -t http://127.0.0.1:8000 -M pb -np
```
The `headertoken[1] == 1` check would still be satisfied and the scan would still proceed.

This is because after the header substitution, the header counter is not updated. Changing this line `headertoken[1] = 1` to `headertoken[1] += 1` fixes that.

Also by the same logic I believe it should be `posttoken[1] == 1` in that condition? I haven't changed that yet as I'm not sure if that was the intention.