### PR TITLE
Fix config generation on Python 3.14

### DIFF
--- a/jwt_tool.py
+++ b/jwt_tool.py
@@ -107,9 +107,9 @@ def createConfig():
                 test_jwks_out.write(fulljwks)
         jwks_b64 = base64.urlsafe_b64encode(fulljwks.encode('ascii'))
     config['services'] = {'jwt_tool_version': jwttoolvers,
-        '# To disable the proxy option set this value to: False (no quotes). For Docker installations with a Windows host OS set this to: "host.docker.internal:8080"': None, 'proxy': proxyHost+':8080',
-        '# To disable following redirects set this value to: False (no quotes)': None, 'redir': 'True',
-        '# Set this to the URL you are hosting your custom JWKS file (jwttool_custom_jwks.json) - your own server, or maybe use this cheeky reflective URL (https://httpbin.org/base64/{base64-encoded_JWKS_here})': None,
+        '# To disable the proxy option set this value to - False (no quotes). For Docker installations with a Windows host OS set this to - "host.docker.internal-8080"': None, 'proxy': proxyHost+':8080',
+        '# To disable following redirects set this value to - False (no quotes)': None, 'redir': 'True',
+        '# Set this to the URL you are hosting your custom JWKS file (jwttool_custom_jwks.json) - your own server, or maybe use this cheeky reflective URL (https-//httpbin.org/base64/{base64-encoded_JWKS_here})': None,
         'jwksloc': '',
         'jwksdynamic': 'https://httpbin.org/base64/'+jwks_b64.decode(),
         '# Set this to the base URL of a Collaborator server, somewhere you can read live logs, a Request Bin etc.': None, 'httplistener': ''}


### PR DESCRIPTION
## Description

Fix an issue that prevents jwt_tool from generating its initial
configuration file when running with Python 3.14.

## Problem

`createConfig()` uses `ConfigParser(allow_no_value=True)` and stores
comment-like strings as no-value option names in order to preserve
comments in the generated `jwtconf.ini`.

Python 3.14's `configparser` performs stricter validation when writing
configuration files and raises `InvalidWriteError` when these option
names contain delimiters such as `:`.

This causes the initial configuration setup to fail with:

```text
configparser.InvalidWriteError:
Cannot write key # To disable the proxy option set this value to: False (no quotes). For Docker installations with a Windows host OS set this to: "host.docker.internal:8080"; contains delimiter :
```

As a result, an incomplete `jwtconf.ini` may be left behind, causing
subsequent executions to fail with errors such as:

```text
KeyError: 'argvals'
```

## Testing

Tested with Python 3.14.6.

Verified that jwt_tool can successfully generate `jwtconf.ini`

This change preserves the existing configuration generation approach
while avoiding the invalid option-name delimiter.